### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - nightly
+
+matrix:
+    allow_failures:
+        - php: nightly
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,17 @@
         "php" : ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^5.7 || ^6.5",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {
         "psr-4": {
             "PHLAK\\Colorizer\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PHLAK\\Colorizer\\Tests\\": "tests/"
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,9 @@
             <directory suffix="Test.php">tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/ColorTest.php
+++ b/tests/ColorTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use PHLAK\Colorizer\Color;
+namespace PHLAK\Colorizer\Tests;
 
-class ColorTest extends PHPUnit_Framework_TestCase
+use PHLAK\Colorizer\Color;
+use PHPUnit\Framework\TestCase;
+
+class ColorTest extends TestCase
 {
     /** @var Color Instance of Colorizer\Color */
     protected $color;
@@ -49,52 +52,59 @@ class ColorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(new Color(64, 162, 224), $normalize);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_initialized_with_an_incorrect_rgb_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         new Color(12, 1337, 234);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function test_it_throws_an_exception_when_initialized_with_an_incorrect_rgb_type()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         new Color('potato', 162, 234);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_initialized_with_an_incorrect_alpha_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         new Color(12, 162, 234, 2);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_normalized_with_a_low_min_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         $this->color->normalize(-1, 42);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_normalized_with_a_high_min_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         $this->color->normalize(256, 42);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_normalized_with_a_low_max_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         $this->color->normalize(42, -1);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_normalized_with_a_high_max_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         $this->color->normalize(42, 256);
     }
 }

--- a/tests/ColorizeTest.php
+++ b/tests/ColorizeTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use PHLAK\Colorizer\Colorize;
+namespace PHLAK\Colorizer\Tests;
 
-class ColorizeTest extends PHPUnit_Framework_TestCase
+use PHLAK\Colorizer\Colorize;
+use PHPUnit\Framework\TestCase;
+
+class ColorizeTest extends TestCase
 {
     /** @var Color Instance of Colorizer\Color */
     protected $color;
@@ -40,31 +43,44 @@ class ColorizeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(224, $normalized->blue);
     }
 
+    public function test_it_can_be_normalized()
+    {
+        $normalized = (new Colorize(64, 224))->normalize(64, 224)->text('Taco bueno!');
+
+        $this->assertEquals(64, $normalized->red);
+        $this->assertEquals(64, $normalized->green);
+        $this->assertEquals(224, $normalized->blue);
+    }
+
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_initialized_with_a_low_min_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         new Colorize(-1, 42);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_initialized_with_a_hight_min_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         new Colorize(256, 42);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_initialized_with_a_low_max_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         new Colorize(42, -1);
     }
 
+    /**
+     * @expectedException \OutOfRangeException
+     */
     public function test_it_throws_an_exception_when_initialized_with_a_hight_max_value()
     {
-        $this->setExpectedException('OutOfRangeException');
-
         new Colorize(42, 256);
     }
 }


### PR DESCRIPTION
# Changed log
- Use class-based PHPUnit namespace to be compatible with latest PHPHUnit version.
- Add other PHP version tests and allow this to be failed in Travis CI build.
- Add more tests.
- After the PHPUnit version ```6.0```, the ````setExpectedException``` is deprecated.
To be compatible with the ```5.7```, we should use the expected exception annotation.